### PR TITLE
refactor: Duration should only be in milliseconds

### DIFF
--- a/proto/spans/v1/span_query_request.proto
+++ b/proto/spans/v1/span_query_request.proto
@@ -74,11 +74,7 @@ message WhereSpanOrFilter {
 }
 
 message Duration {
-  oneof value {
-    uint64 secondsValue = 1;
-    uint64 millisecondsValue = 2;
-    uint64 minutesValue = 3;
-  }
+  int32 milliseconds = 1;
 }
 
 message StringProperty {


### PR DESCRIPTION
Removed seconds and minutes from Duration. It is now only in milliseconds.

Also changed the type from uint64 to int32.